### PR TITLE
Superseded: Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,11 @@ More information about the React component: https://github.com/rrag/react-stockc
 ### Build Tooling
 
 This project uses modern `@wordpress/scripts` tooling for block build and development workflows.
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/gutenberg-stocks.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/gutenberg-stocks.svg before updating the README.
- Ran git diff --check for the README change.